### PR TITLE
docs: brand-readiness for first OSS release (agent-native reframe, intake templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,54 @@
+name: Bug report
+description: Report a reproducible problem in Erfana
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please **do not** report security
+        vulnerabilities here — use [private advisory reporting](https://github.com/qodeca/erfana/security/advisories/new) instead.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including what you expected to happen.
+      placeholder: When I open a project with… Erfana…
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal, ordered steps that reliably reproduce the problem.
+      placeholder: |
+        1. Open a folder with…
+        2. Click…
+        3. See…
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Erfana version
+      description: Help → About, or the app's version string.
+      placeholder: "0.16.1"
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Windows
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Relevant log output (Settings shows the logs folder path) or screenshots. Redact anything sensitive.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -49,6 +49,5 @@ body:
     attributes:
       label: Logs or screenshots
       description: Relevant log output (Settings shows the logs folder path) or screenshots. Redact anything sensitive.
-      render: shell
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability (private)
+    url: https://github.com/qodeca/erfana/security/advisories/new
+    about: Do not open a public issue for security problems — report them privately here.
+  - name: Security policy
+    url: https://github.com/qodeca/erfana/blob/main/SECURITY.md
+    about: How Erfana handles vulnerability reports, scope, and disclosure.
+  - name: Questions & ideas
+    url: https://github.com/qodeca/erfana/discussions
+    about: Ask questions, share ideas, or discuss usage in Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest an idea or enhancement for Erfana
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question or an open-ended idea instead? Please start a
+        [Discussion](https://github.com/qodeca/erfana/discussions) — this form is for concrete feature requests.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What are you trying to do, and where does Erfana fall short today?
+      placeholder: When working on… I can't…
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the feature or change you'd like to see.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or workarounds you've tried or thought about.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+SPDX-License-Identifier: GPL-3.0-only
+SPDX-FileCopyrightText: 2025-2026 Qodeca sp. z o.o.
+-->
+
+## Summary
+
+<!-- What does this PR change, and why? Link any related issue (e.g. "Closes #123"). -->
+
+## Changes
+
+<!-- Bullet the notable changes. -->
+
+-
+
+## Checklist
+
+- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`).
+- [ ] `npm run lint` and `npm run typecheck` pass.
+- [ ] `npm run test:ci` passes (added/updated tests where it makes sense).
+- [ ] `npx electron-vite build` succeeds.
+- [ ] `npm run check:headers` and `reuse lint` pass (SPDX headers / REUSE compliance).
+- [ ] Ran `npm run test:e2e` locally if this touches Electron-specific paths (CI does not cover e2e).
+- [ ] Documentation updated if behavior or APIs changed.
+
+> First-time contributors: the **CLA-assistant** bot will comment on this PR with a one-time link to sign the [Contributor License Agreement](../CLA.md). Signing is required before merge; the bot handles it automatically — there's nothing to do up front.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,9 @@
 # ERFANA - Project Instructions for Claude
 
 ## Project Overview
-An AI-native Markdown workspace (Electron) that runs terminal coding agents like Claude Code beside the editor — integrated terminal with a live Claude Code context-window meter, Monaco editor + live preview, and a project tree. Positioning: an "AI-native Markdown workspace," agent-agnostic with Claude Code as the lead example; Erfana hosts/companions the agent (it is not itself an AI model — never overclaim built-in AI).
+An agent-native Markdown workspace (Electron) that runs terminal coding agents like Claude Code beside the editor — integrated terminal with a live Claude Code context-window meter, Monaco editor + live preview, and a project tree. Positioning: an "agent-native Markdown workspace," agent-agnostic with Claude Code as the lead example; Erfana hosts/companions the agent (it is not itself an AI model — never overclaim built-in AI). Note: the context-window meter is Claude Code-specific (reads `~/.claude` transcripts); the terminal itself runs any CLI agent.
 - **Repository**: `qodeca/erfana` (GitHub, public)
-- **Version**: 0.16.0
+- **Version**: 0.16.1
 - **License**: `GPL-3.0-only` (open source). Copyright (c) 2025-2026 **Qodeca sp. z o.o.** See [LICENSE](LICENSE) and [COPYRIGHT](COPYRIGHT) (relicensing record). Per-file licensing follows the [REUSE](https://reuse.software) spec (SPDX headers + `REUSE.toml`); third-party notices are in [THIRD-PARTY-LICENSES.md](THIRD-PARTY-LICENSES.md). The code is GPL; the "Erfana"/"Qodeca" names and logos remain Qodeca trademarks (see [TRADEMARKS.md](TRADEMARKS.md)) — forks must rebrand. Contributions require the project CLA (see [CLA.md](CLA.md)), which preserves Qodeca's dual-licensing option. `"private": true` in package.json is a publish guard for the desktop app, not a license statement.
 - **Tech Stack**: Electron 39, React 18, TypeScript 6.0, Monaco Editor, xterm.js
 - **Build Toolchain**: electron-vite 5, Vite 6, vitest 3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # ERFANA - Project Instructions for Claude
 
 ## Project Overview
-Electron-based markdown IDE with integrated terminal and project management.
+An AI-native Markdown workspace (Electron) that runs terminal coding agents like Claude Code beside the editor — integrated terminal with a live Claude Code context-window meter, Monaco editor + live preview, and a project tree. Positioning: an "AI-native Markdown workspace," agent-agnostic with Claude Code as the lead example; Erfana hosts/companions the agent (it is not itself an AI model — never overclaim built-in AI).
 - **Repository**: `qodeca/erfana` (GitHub, public)
 - **Version**: 0.16.0
 - **License**: `GPL-3.0-only` (open source). Copyright (c) 2025-2026 **Qodeca sp. z o.o.** See [LICENSE](LICENSE) and [COPYRIGHT](COPYRIGHT) (relicensing record). Per-file licensing follows the [REUSE](https://reuse.software) spec (SPDX headers + `REUSE.toml`); third-party notices are in [THIRD-PARTY-LICENSES.md](THIRD-PARTY-LICENSES.md). The code is GPL; the "Erfana"/"Qodeca" names and logos remain Qodeca trademarks (see [TRADEMARKS.md](TRADEMARKS.md)) — forks must rebrand. Contributions require the project CLA (see [CLA.md](CLA.md)), which preserves Qodeca's dual-licensing option. `"private": true` in package.json is a publish guard for the desktop app, not a license statement.

--- a/README.md
+++ b/README.md
@@ -1,171 +1,64 @@
 # Erfana
 
+**Open-source Markdown IDE with an AI-native terminal and signed builds — for macOS & Windows.**
+
+[![Quality Checks](https://github.com/qodeca/erfana/actions/workflows/checks.yml/badge.svg?branch=main)](https://github.com/qodeca/erfana/actions/workflows/checks.yml)
+[![Latest release](https://img.shields.io/github/v/release/qodeca/erfana?sort=semver)](https://github.com/qodeca/erfana/releases)
 [![License: GPL-3.0-only](https://img.shields.io/badge/License-GPLv3-blue.svg)](./LICENSE)
-[![REUSE compliant](https://img.shields.io/badge/REUSE-compliant-brightgreen.svg)](https://reuse.software)
+[![Platforms: macOS · Windows](https://img.shields.io/badge/platforms-macOS%20%C2%B7%20Windows-lightgrey.svg)](#platforms)
 
-An Electron-based project workspace focused on markdown editing, a project tree, and an integrated terminal. Free software, licensed under **GPL-3.0-only**.
+Erfana is a desktop workspace for working in Markdown next to a real terminal: a Monaco-powered editor with live preview, a project tree with live git status, and an integrated terminal where AI text operations and CLI tools (including Claude Code) run in your project's context. It is free software under **GPL-3.0-only**.
 
-> **Documentation:** [docs/](docs/README.md) · **Architecture:** [docs/architecture.md](docs/architecture.md) · **Changelog:** [docs/CHANGELOG.md](docs/CHANGELOG.md) · **Contributing:** [CONTRIBUTING.md](CONTRIBUTING.md)
+| | |
+|---|---|
+| 📝 **Markdown editor** | Monaco editor, live preview with scroll sync, Mermaid diagrams (22 types, zoom/pan/full-screen), YAML frontmatter, unified in-file search |
+| 💻 **Integrated terminal** | xterm.js + PTY with WebGL rendering, file links, drag-drop paths, cross-platform screenshot & camera capture, and a per-panel Claude Code context status bar |
+| 🤖 **AI text operations** | Right-click prompt templates (Explain, Modify, Ask, Visualize) routed to the terminal; mutation prompts apply edits back to the document |
+| 📁 **Project tree** | Real-time git status (worker-thread offloaded), drag-drop reorganization, Markdown filtering, Reveal in Finder/Explorer |
+| 📄 **Import & export** | 50+ document formats via LiteParse with local OCR; print-optimized PDF and Word (DOCX) export with Mermaid diagrams |
+| 🎙️ **Media transcription** | Audio/video → text via the OpenAI API or fully offline `whisper.cpp` |
 
-## Features
+## Platforms
 
-- 🎨 **Multi-Panel IDE Layout**: Hybrid SplitviewReact + DockviewReact with resizable panels
-- 📝 **Superior Markdown Editing**: Monaco Editor with live preview, scroll sync, Mermaid diagrams, and formatting toolbar
-- 📁 **Smart Project Management**: Project tree with markdown filtering, visual indicators, and context menu operations
-- 🔄 **Auto-Refresh**: Automatic file and directory tree updates on external changes
-- 💻 **Integrated Terminal**: Full-featured xterm.js terminal with WebGL rendering and traditional zsh prompt
- - ⚡ **AI-Powered Text Operations**: Right-click context menu with prompt templates for text elaboration, improvement, and more (send to Terminal)
+macOS and Windows. There is no Linux build.
 
-## Tech Stack
+## Getting started
 
-- **Electron** + **electron-vite**: Modern Electron development
-- **React** + **TypeScript**: UI framework with full type safety
-- **SplitviewReact** + **DockviewReact**: Hybrid layout system matching VS Code architecture
-- **Monaco Editor**: VS Code's editor engine for code editing
-- **xterm.js** + **node-pty**: Full-featured terminal emulator with PTY support
-- **electron-store**: Settings persistence
-- **Mermaid.js**: Diagram rendering (22 diagram types)
+1. Download the signed build for your OS from **[Releases](https://github.com/qodeca/erfana/releases)**.
+2. Install it (macOS: open the `.dmg`; Windows: run the setup `.exe`).
+3. Launch Erfana and open a project folder — the editor, project tree, and terminal open in context.
 
-## Development
+**[⬇ Download](https://github.com/qodeca/erfana/releases)** · **[🌐 qodeca.com](https://qodeca.com)**
 
-### Prerequisites
+Prefer to build from source? See [Development](#development).
 
-- Node.js 24+ (Electron 39 bundles Node 22.20.0; build toolchain needs 24+)
-- Python 3.12 (**not 3.13** — `node-pty` fails to build on 3.13)
-- Git
-- **On Windows**: VS 2022 Build Tools, Developer Mode enabled, Win32 long paths enabled. See [`docs/build/windows.md`](docs/build/windows.md) for full setup.
+## Why open source, and how it's licensed
 
-### Setup
+Erfana is free software under **GPL-3.0-only**: you can use, study, modify, and redistribute it under the GPL. We build a lot of our tooling in the open and wanted Erfana to be useful beyond our own work.
 
-```bash
-# Install dependencies
-npm install
+Contributions are accepted under a [Contributor License Agreement](CLA.md) that preserves Qodeca's option to also offer Erfana under separate commercial terms — this does **not** restrict your rights under the GPL. The code is GPL; the **name and branding** are not (see [Trademarks](#trademarks)).
 
-# Start development server
-npm run dev
+## Built by Qodeca
 
-# Build for production
-npm run build
+Erfana is built by **[Qodeca](https://qodeca.com)** — a Warsaw-based software team building software since 2014 for the fitness, sport, and healthcare industries, where HIPAA, GDPR, and PCI DSS are the baseline, not the exception.
 
-# Package for distribution
-npm run build:mac   # macOS
-npm run build:win   # Windows
-```
+The same rigor shows up in Erfana: minisign-signed and notarized release artifacts, a documented four-layer trust chain for the bundled Whisper binaries, sandboxed renderers with a validated IPC layer, and a full CI gate on every push. We build in the open elsewhere too — see [erfana-skills](https://github.com/qodeca/erfana-skills) (Claude Code plugin) and [8cli](https://github.com/qodeca/8cli) (AI-first n8n CLI).
 
-### Project Structure
-
-```
-erfana/
-├── src/
-│   ├── main/              # Electron main process
-│   │   ├── index.ts       # App entry point
-│   │   └── services/      # Business logic (Terminal, File, Settings)
-│   ├── preload/           # Secure IPC bridge
-│   │   └── index.ts       # contextBridge API
-│   └── renderer/          # React UI
-│       ├── src/
-│       │   ├── components/
-│       │   │   ├── DockLayout/      # Dockview setup
-│       │   │   ├── Panels/          # Panel components
-│       │   │   ├── Editor/          # Monaco editor
-│       │   │   ├── Terminal/        # xterm.js
-│       │   │   ├── ProjectTree/     # Project explorer
-│       │   │   └── Toolbar/         # Editor toolbar
-│       │   ├── hooks/               # React hooks
-│       │   ├── stores/              # State management
-│       │   └── types/               # TypeScript types
-│       └── index.html
-├── resources/             # App icons and assets
-└── electron-builder.yml  # Build configuration
-```
-
-## Architecture
-
-### Main Process
-- Window management
-- File system operations (with auto-refresh via chokidar)
-- Claude CLI session management (persistent process with JSONL I/O)
-- Terminal PTY management (xterm.js + node-pty)
-- IPC handlers (reduced after feature cleanup)
-
-### Preload
-- Secure contextBridge API
-- Type-safe IPC channels
-
-### Renderer
-- React-based UI with hybrid SplitviewReact + DockviewReact layout
-- Dual activity bars (left/right) for panel management
-- Monaco Editor with formatting toolbar and document statistics
-- Markdown preview with scroll sync and Mermaid diagram support
-- xterm.js terminal with WebGL rendering
-- Prompt template system (CSP-safe, YAML frontmatter + Handlebars-style syntax)
-- State management with Zustand
-
-## Key Workflows
-
-### 1. AI-Powered Text Operations
-1. Open a markdown file in split view (editor + preview)
-2. Select text in the preview pane
-3. Right-click and choose prompt template (Explain, Modify, Ask, Visualize, or custom)
-4. Prompt is sent to the Terminal panel based on template configuration
-5. Review AI response and iterate
-6. File references include precise line numbers for context
-
-### 2. Terminal Usage
-Open the Terminal panel from the right activity bar to run shell commands in the project context. cmd.exe / PowerShell / pwsh 7 + POSIX shells supported (Phase 1 #154).
-
-### 3. Markdown Editing
-1. Open markdown files in Monaco editor
-2. Use formatting toolbar for quick markdown syntax
-3. Switch view modes: Editor only, Split view (with scroll sync), or Preview only
-4. Preview renders Mermaid diagrams (22 types supported)
-5. Auto-save after 2 seconds of inactivity
-6. Document statistics displayed in bottom bar
-
-### 4. Project Management
-1. Open project folder (auto-loads last project on startup)
-2. Browse file tree with markdown filtering
-3. Visual indicators for sensitive files and hidden files
-4. Context menu for New File, New Folder, Rename, Delete
-5. Auto-refresh on external changes (git operations, npm installs, etc.)
-6. Multiple files open in tabs with independent state
-
-## Security
-
-- Context isolation enabled
-- No node integration in renderer
-- Secure IPC via contextBridge
-- Content Security Policy (CSP) headers
-- Input validation on all IPC channels
-
-Details: [`docs/security.md`](docs/security.md). Release-artifact trust chain (minisign-signed `SHA256SUMS`, macOS notarization, Windows Azure Artifact Signing): [`docs/build/release.md`](docs/build/release.md).
+[qodeca.com](https://qodeca.com) · [LinkedIn](https://www.linkedin.com/company/qodecasoftwaredevelopment) · [hi@qodeca.com](mailto:hi@qodeca.com)
 
 ## Release verification
 
-Every release on or after `v0.9.5` ships signed artifacts. End users should verify downloads before installing:
+Every release on or after `v0.9.5` ships signed artifacts: a minisign-signed `SHA256SUMS`, macOS notarization, and Windows Authenticode. Verify downloads before installing — the release-signing public keys and the step-by-step `minisign` + `sha256sum` recipe live in [`docs/security.md`](docs/security.md#release-signing-v095-174) and [`docs/build/release.md`](docs/build/release.md), with the keys mirrored in [`docs/release-pubkey.txt`](docs/release-pubkey.txt).
 
-```bash
-# Aggregate integrity + minisign signature over SHA256SUMS (accept PRIMARY or ROTATION key)
-PRIMARY="RWRGVoSZhM7rShmOHr5lmt6v6wH8Tjm/nXItCg46Co+hxgvJFLWkv0fC"
-ROTATION="RWTxkJcmBbLk6J2eWEDWHYcAmgpKfRqO5PR8oRRLUpgn5rgCaWmTvd9w"
-minisign -V -P "$PRIMARY"  -m SHA256SUMS -x SHA256SUMS.minisig \
-  || minisign -V -P "$ROTATION" -m SHA256SUMS -x SHA256SUMS.minisig
-sha256sum -c SHA256SUMS
-```
+## Security
 
-The dedicated release-signing minisign public keys (primary + rotation) are published at [`docs/release-pubkey.txt`](docs/release-pubkey.txt) and mirrored in [`docs/security.md § Release signing`](docs/security.md#release-signing-v095-174). These keys are **separate** from the `whisper-binaries` key — compromising one does not weaken the other.
+Erfana enables context isolation, disables node integration in the renderer, exposes a sandboxed `contextBridge` IPC layer with input validation on every channel, and applies a Content Security Policy. Details: [`docs/security.md`](docs/security.md).
 
-> **Note on SLSA provenance:** GitHub-hosted Artifact Attestations (SLSA Build L2) are [only available on Enterprise Cloud for private repositories](https://docs.github.com/en/actions/concepts/security/artifact-attestations). Erfana's trust chain relies on minisign (aggregate `SHA256SUMS`) + codesign-notarization (macOS) + Authenticode (Windows) instead; these provide equivalent authenticity guarantees without the Enterprise plan.
-
-## Contributing
-
-Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) and our [Code of Conduct](CODE_OF_CONDUCT.md). Contributions are accepted under **GPL-3.0-only** and require signing the project [Contributor License Agreement](CLA.md) (a CLA-assistant check runs on each pull request), which preserves Qodeca's option to offer Erfana under additional terms.
-
-Report security vulnerabilities privately — see [SECURITY.md](SECURITY.md).
+Report security vulnerabilities **privately** via [GitHub's private advisory reporting](https://github.com/qodeca/erfana/security/advisories/new) — see [SECURITY.md](SECURITY.md). Please do not open a public issue for an unfixed vulnerability.
 
 ## License
 
-Erfana is free software, licensed under the **GNU General Public License v3.0 only** (`GPL-3.0-only`) — see [LICENSE](LICENSE), [COPYRIGHT](COPYRIGHT), and bundled third-party notices in [THIRD-PARTY-LICENSES.md](THIRD-PARTY-LICENSES.md). Per-file licensing follows the [REUSE specification](https://reuse.software).
+Erfana is free software, licensed under the **GNU General Public License v3.0 only** (`GPL-3.0-only`) — see [LICENSE](LICENSE), [COPYRIGHT](COPYRIGHT), and bundled third-party notices in [THIRD-PARTY-LICENSES.md](THIRD-PARTY-LICENSES.md). Per-file licensing follows the [REUSE specification](https://reuse.software) (SPDX headers + `REUSE.toml`).
 
 Copyright (c) 2025-2026 Qodeca sp. z o.o.
 
@@ -173,6 +66,22 @@ Copyright (c) 2025-2026 Qodeca sp. z o.o.
 
 The GPL covers Erfana's **code**, not its **name or branding**. "Erfana" and "Qodeca", and the associated logos, are trademarks of Qodeca sp. z o.o. You may use and fork the software under the GPL, but distributions of modified versions must be **renamed** — see [TRADEMARKS.md](TRADEMARKS.md). Qodeca publishes the official signed builds.
 
-## Author
+## Contributing
 
-Qodeca sp. z o.o.
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) and our [Code of Conduct](CODE_OF_CONDUCT.md). Contributions are accepted under **GPL-3.0-only** and require signing the project [Contributor License Agreement](CLA.md); the CLA-assistant bot prompts first-time contributors automatically on their pull request.
+
+## Development
+
+Build Erfana from source:
+
+```bash
+npm install      # Node.js 24+; Python 3.12 (not 3.13 — node-pty); see below for Windows
+npm run dev      # development server
+npm run build    # production build
+npm run build:mac   # package for macOS
+npm run build:win   # package for Windows
+```
+
+**On Windows:** VS 2022 Build Tools, Developer Mode, and Win32 long paths are required — see [`docs/build/windows.md`](docs/build/windows.md).
+
+Architecture, services, IPC patterns, testing, and the full contributor workflow are documented in **[docs/](docs/README.md)** · [Architecture](docs/architecture.md) · [Build](docs/build/README.md) · [Testing](docs/testing/README.md) · [Changelog](docs/CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -1,19 +1,26 @@
 # Erfana
 
-**Open-source Markdown IDE with an AI-native terminal and signed builds — for macOS & Windows.**
+**An open-source, AI-native Markdown workspace — run a terminal coding agent like Claude Code right beside your editor.**
 
 [![Quality Checks](https://github.com/qodeca/erfana/actions/workflows/checks.yml/badge.svg?branch=main)](https://github.com/qodeca/erfana/actions/workflows/checks.yml)
 [![Latest release](https://img.shields.io/github/v/release/qodeca/erfana?sort=semver)](https://github.com/qodeca/erfana/releases)
 [![License: GPL-3.0-only](https://img.shields.io/badge/License-GPLv3-blue.svg)](./LICENSE)
 [![Platforms: macOS · Windows](https://img.shields.io/badge/platforms-macOS%20%C2%B7%20Windows-lightgrey.svg)](#platforms)
 
-Erfana is a desktop workspace for working in Markdown next to a real terminal: a Monaco-powered editor with live preview, a project tree with live git status, and an integrated terminal where AI text operations and CLI tools (including Claude Code) run in your project's context. It is free software under **GPL-3.0-only**.
+Erfana puts a coding agent at the center of your Markdown work. Open a project and the agent, your files, and your live preview share one window — and one feedback loop:
+
+- **Run the agent in your editor** — a clean top-level `claude` session (or any CLI agent) in the integrated terminal, in your project's context.
+- **Watch its context** — a per-panel meter shows the model, its 200k/1M context window, and how full it is, live.
+- **Turn Markdown into prompts** — right-click a selection for prompt templates (Explain, Modify, Ask, Visualize); the prompt goes straight to the agent.
+- **Edits land in your file** — mutation prompts apply the agent's changes back into the document.
+
+It is free software under **GPL-3.0-only**, for macOS & Windows.
 
 | | |
 |---|---|
+| 🤖 **AI workflow** | Run Claude Code (or any CLI agent) in the integrated terminal; a per-panel meter tracks the model and live context-window usage; right-click prompt templates turn Markdown into prompts and apply edits back to the file |
+| 💻 **Integrated terminal** | xterm.js + PTY with WebGL rendering, file links, drag-drop paths, cross-platform screenshot & camera capture |
 | 📝 **Markdown editor** | Monaco editor, live preview with scroll sync, Mermaid diagrams (22 types, zoom/pan/full-screen), YAML frontmatter, unified in-file search |
-| 💻 **Integrated terminal** | xterm.js + PTY with WebGL rendering, file links, drag-drop paths, cross-platform screenshot & camera capture, and a per-panel Claude Code context status bar |
-| 🤖 **AI text operations** | Right-click prompt templates (Explain, Modify, Ask, Visualize) routed to the terminal; mutation prompts apply edits back to the document |
 | 📁 **Project tree** | Real-time git status (worker-thread offloaded), drag-drop reorganization, Markdown filtering, Reveal in Finder/Explorer |
 | 📄 **Import & export** | 50+ document formats via LiteParse with local OCR; print-optimized PDF and Word (DOCX) export with Mermaid diagrams |
 | 🎙️ **Media transcription** | Audio/video → text via the OpenAI API or fully offline `whisper.cpp` |

--- a/README.md
+++ b/README.md
@@ -1,28 +1,27 @@
 # Erfana
 
-**An open-source, AI-native Markdown workspace — run a terminal coding agent like Claude Code right beside your editor.**
+**An open-source, agent-native Markdown workspace — run a terminal coding agent like Claude Code right beside your editor.**
 
 [![Quality Checks](https://github.com/qodeca/erfana/actions/workflows/checks.yml/badge.svg?branch=main)](https://github.com/qodeca/erfana/actions/workflows/checks.yml)
 [![Latest release](https://img.shields.io/github/v/release/qodeca/erfana?sort=semver)](https://github.com/qodeca/erfana/releases)
 [![License: GPL-3.0-only](https://img.shields.io/badge/License-GPLv3-blue.svg)](./LICENSE)
 [![Platforms: macOS · Windows](https://img.shields.io/badge/platforms-macOS%20%C2%B7%20Windows-lightgrey.svg)](#platforms)
 
-Erfana puts a coding agent at the center of your Markdown work. Open a project and the agent, your files, and your live preview share one window — and one feedback loop:
+Erfana puts a coding agent beside your Markdown work — one window holds the editor, live preview, project tree, and a terminal running your agent. Open a project and they share one feedback loop:
 
 - **Run the agent in your editor** — a clean top-level `claude` session (or any CLI agent) in the integrated terminal, in your project's context.
-- **Watch its context** — a per-panel meter shows the model, its 200k/1M context window, and how full it is, live.
+- **Watch its context** — for a Claude Code session, a per-panel meter shows the model, its 200k/1M context window, and how full it is, live.
 - **Turn Markdown into prompts** — right-click a selection for prompt templates (Explain, Modify, Ask, Visualize); the prompt goes straight to the agent.
 - **Edits land in your file** — mutation prompts apply the agent's changes back into the document.
 
-It is free software under **GPL-3.0-only**, for macOS & Windows.
+It is free software under **GPL-3.0-only**.
 
 | | |
 |---|---|
-| 🤖 **AI workflow** | Run Claude Code (or any CLI agent) in the integrated terminal; a per-panel meter tracks the model and live context-window usage; right-click prompt templates turn Markdown into prompts and apply edits back to the file |
-| 💻 **Integrated terminal** | xterm.js + PTY with WebGL rendering, file links, drag-drop paths, cross-platform screenshot & camera capture |
+| 💻 **Integrated terminal** | Run Claude Code or any CLI agent in an xterm.js + PTY terminal with WebGL rendering, file links, drag-drop paths, and cross-platform screenshot & camera capture |
 | 📝 **Markdown editor** | Monaco editor, live preview with scroll sync, Mermaid diagrams (22 types, zoom/pan/full-screen), YAML frontmatter, unified in-file search |
 | 📁 **Project tree** | Real-time git status (worker-thread offloaded), drag-drop reorganization, Markdown filtering, Reveal in Finder/Explorer |
-| 📄 **Import & export** | 50+ document formats via LiteParse with local OCR; print-optimized PDF and Word (DOCX) export with Mermaid diagrams |
+| 📄 **Import & export** | Import via LiteParse (which handles 50+ formats) with local OCR — Office/image formats need LibreOffice/ImageMagick; print-optimized PDF and Word (DOCX) export with Mermaid diagrams |
 | 🎙️ **Media transcription** | Audio/video → text via the OpenAI API or fully offline `whisper.cpp` |
 
 ## Platforms
@@ -72,6 +71,8 @@ Copyright (c) 2025-2026 Qodeca sp. z o.o.
 ## Trademarks
 
 The GPL covers Erfana's **code**, not its **name or branding**. "Erfana" and "Qodeca", and the associated logos, are trademarks of Qodeca sp. z o.o. You may use and fork the software under the GPL, but distributions of modified versions must be **renamed** — see [TRADEMARKS.md](TRADEMARKS.md). Qodeca publishes the official signed builds.
+
+"Claude" and "Claude Code" are trademarks of Anthropic. Erfana is not affiliated with, sponsored by, or endorsed by Anthropic — it simply runs the `claude` CLI like any other terminal program.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "erfana",
   "version": "0.16.1",
-  "description": "An AI-native Markdown workspace that runs terminal coding agents like Claude Code beside your editor",
+  "description": "An agent-native Markdown workspace that runs terminal coding agents like Claude Code beside your editor",
   "main": "./out/main/index.js",
   "author": "Qodeca sp. z o.o.",
   "license": "GPL-3.0-only",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "erfana",
   "version": "0.16.1",
-  "description": "Project IDE with Markdown, Project Tree, and Terminal",
+  "description": "An AI-native Markdown workspace that runs terminal coding agents like Claude Code beside your editor",
   "main": "./out/main/index.js",
   "author": "Qodeca sp. z o.o.",
   "license": "GPL-3.0-only",


### PR DESCRIPTION
Prepares the public GitHub surfaces for Erfana's first open-source release as a Qodeca brand / developer-visibility play. Scoped via grill-me and twice run through \`erfana:lens-review\` (QG-4 plan review + post-implementation review); all findings applied.

## What's in here

**README — rewritten as a brand surface, then reframed agent-first**
- Positioned as an **agent-native, open-source Markdown workspace** that runs a terminal coding agent like Claude Code beside the editor (honest host/companion framing — Erfana is not itself an AI model).
- Hero tagline, curated badge row, feature table (text-only launch by decision), platforms line, getting-started, Download/Website CTAs, an anti-openwashing "why open source / how it's licensed" note, and a facts-based "Built by Qodeca" block.
- Accuracy fixes from lens-review: context-window meter scoped to Claude Code (it reads \`~/.claude\` transcripts; the terminal runs any agent); "50+ formats" qualified as LiteParse's reach (Office/image need LibreOffice/ImageMagick); Anthropic non-affiliation/trademark note; redundant feature row dropped; repetition trimmed.
- No release pubkeys inline (keeps the \`checks.yml\` pubkey-drift guard green).

**Inbound intake → Community Standards 100%**
- \`.github/ISSUE_TEMPLATE/{bug_report,feature_request}.yml\` + \`config.yml\` (security routed to the private advisory form, questions to Discussions, blank issues off).
- \`.github/PULL_REQUEST_TEMPLATE.md\` — quality-gate checklist; CLA framed as an informational last item (CLA-assistant enforces).

**Metadata alignment**
- \`package.json\` description and \`CLAUDE.md\` overview reframed agent-native; CLAUDE.md version → 0.16.1.

## Already applied live (repo metadata, separately authorized)
- About reworded agent-native; homepage set to qodeca.com; topics expanded to 17 (incl. \`ai\`, \`claude-code\`, \`ai-agents\`, \`coding-agent\`; \`llm\` removed as an over-claim).

## Verification
- \`npm run check:headers\` (766 files) and \`reuse lint\` (REUSE 3.3 compliant) green; issue forms valid; Guard 5 clean (no pubkeys in README); all README link targets resolve.

## Not in scope / gated
- Org-profile "Open source at Qodeca" line (separate \`qodeca/.github\` repo) — apply with agent-native wording at the gated org step.
- Pre-launch gates: publish v0.16.1 before the README goes public (Download CTA / release badge), verify the qodeca.com domain before org changes, upload the social-preview card before sharing links.