### PR TITLE
feat(screenshot): actionable macOS Screen Recording permission flow

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -91,6 +91,7 @@ mac:
   extendInfo:
     - NSCameraUsageDescription: Erfana uses the camera to capture photos you insert into notes.
     - NSMicrophoneUsageDescription: Erfana uses the microphone for audio transcription you request.
+    - NSScreenCaptureUsageDescription: Erfana captures screenshots you insert into notes and terminals.
     - NSDocumentsFolderUsageDescription: Erfana reads and writes project files in folders you open.
     - NSDownloadsFolderUsageDescription: Erfana writes exported files (PDF, DOCX) to folders you choose.
   # Notarization is auto-invoked by electron-builder 26 when either:

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,6 +16,7 @@ import { registerPdfHandlers } from './ipc/pdf-handlers'
 import { registerDocxHandlers } from './ipc/docx-handlers'
 import { registerScreenshotHandlers } from './ipc/screenshot-handlers'
 import { registerShellHandlers } from './ipc/shell-handlers'
+import { registerSystemHandlers } from './ipc/system-handlers'
 import { registerCameraHandlers } from './ipc/camera-handlers'
 import { registerGlobalSettingsHandlers } from './ipc/global-settings-handlers'
 import { registerLoggingHandlers } from './ipc/logging-handlers'
@@ -232,6 +233,7 @@ app.whenReady().then(async () => {
   registerDocxHandlers()
   registerScreenshotHandlers()
   registerShellHandlers()
+  registerSystemHandlers()
   registerCameraHandlers()
   registerGlobalSettingsHandlers()
   registerLoggingHandlers()

--- a/src/main/ipc/screenshot-handlers.test.ts
+++ b/src/main/ipc/screenshot-handlers.test.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2025-2026 Qodeca sp. z o.o.
+/**
+ * Tests for the screenshot IPC handlers — focused on the advisory
+ * screen-recording permission channel added for the grant-and-relaunch UX.
+ *
+ * Mirrors the sender-validation harness in `clipboard-handlers.test.ts`:
+ * mock `ipcMain.handle` to capture handler fns, mock a controllable `is.dev`,
+ * and pin the trusted frame to the exact bundled renderer file URL.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { join } from 'path'
+import { pathToFileURL } from 'url'
+import type { IpcMainInvokeEvent } from 'electron'
+import { SCREENSHOT_CHANNELS } from '../../shared/ipc/screenshot-channels'
+import type { IScreenshotService } from '../services/ScreenshotService'
+
+const mockIpcMainHandle = vi.fn()
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: mockIpcMainHandle },
+  systemPreferences: { getMediaAccessStatus: vi.fn(() => 'granted') }
+}))
+
+const mockIs = { dev: false }
+vi.mock('@electron-toolkit/utils', () => ({ is: mockIs }))
+
+const RENDERER_FILE_URL = pathToFileURL(join(__dirname, '../renderer/index.html')).href
+
+const mockLogger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn()
+}
+vi.mock('../services/LoggingService', () => ({ logger: mockLogger }))
+
+function makeEvent(frame: { url: string; parent: unknown } | null): IpcMainInvokeEvent {
+  return { senderFrame: frame } as unknown as IpcMainInvokeEvent
+}
+
+const TRUSTED_FRAME = { url: RENDERER_FILE_URL, parent: null }
+
+function stubService(overrides: Partial<IScreenshotService> = {}): IScreenshotService {
+  return {
+    getDisplays: vi.fn(() => []),
+    getCapabilities: vi.fn(() => ({
+      supported: true,
+      hasNativeWindowPicker: true,
+      areaCaptureMode: 'native' as const
+    })),
+    getScreenRecordingPermission: vi.fn(() => 'granted' as const),
+    enumerateWindows: vi.fn(async () => ({
+      availability: 'native-picker' as const,
+      sources: [] as [],
+      truncated: false
+    })),
+    capture: vi.fn(async () => ({ success: true, filePath: '/tmp/x.png' })),
+    ...overrides
+  }
+}
+
+async function getHandler(
+  channel: string,
+  service: IScreenshotService
+): Promise<(...args: unknown[]) => Promise<unknown>> {
+  const { registerScreenshotHandlers } = await import('./screenshot-handlers')
+  registerScreenshotHandlers(service)
+  const handler = mockIpcMainHandle.mock.calls.find((call) => call[0] === channel)?.[1]
+  expect(handler).toBeDefined()
+  return handler as (...args: unknown[]) => Promise<unknown>
+}
+
+describe('screenshot-handlers — getScreenPermission', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    delete process.env['ELECTRON_RENDERER_URL']
+    mockIs.dev = false
+  })
+
+  it('registers the getScreenPermission channel', async () => {
+    const { registerScreenshotHandlers } = await import('./screenshot-handlers')
+    registerScreenshotHandlers(stubService())
+    expect(mockIpcMainHandle).toHaveBeenCalledWith(
+      SCREENSHOT_CHANNELS.GET_SCREEN_PERMISSION,
+      expect.any(Function)
+    )
+  })
+
+  it('returns the service permission value for a trusted sender', async () => {
+    const service = stubService({
+      getScreenRecordingPermission: vi.fn(() => 'denied' as const)
+    })
+    const handler = await getHandler(SCREENSHOT_CHANNELS.GET_SCREEN_PERMISSION, service)
+
+    const result = await handler(makeEvent(TRUSTED_FRAME))
+
+    expect(result).toBe('denied')
+    expect(service.getScreenRecordingPermission).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns "unknown" and does not query the service for an untrusted sender', async () => {
+    const service = stubService()
+    const handler = await getHandler(SCREENSHOT_CHANNELS.GET_SCREEN_PERMISSION, service)
+
+    const result = await handler(makeEvent({ url: 'https://evil.example', parent: null }))
+
+    expect(result).toBe('unknown')
+    expect(service.getScreenRecordingPermission).not.toHaveBeenCalled()
+    expect(mockLogger.warn).toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/screenshot-handlers.ts
+++ b/src/main/ipc/screenshot-handlers.ts
@@ -13,7 +13,8 @@ import {
   type ScreenshotCaptureResponse,
   type GetDisplaysResponse,
   type EnumerateWindowsResponse,
-  type ScreenshotCapabilities
+  type ScreenshotCapabilities,
+  type ScreenRecordingPermission
 } from '../../shared/ipc/screenshot-schema'
 import { logger } from '../services/LoggingService'
 
@@ -103,6 +104,27 @@ export function registerScreenshotHandlers(
       } catch (error) {
         logger.error('getCapabilities failed', error instanceof Error ? error : undefined)
         return { supported: false, hasNativeWindowPicker: false, areaCaptureMode: 'unsupported' }
+      }
+    }
+  )
+
+  ipcMain.handle(
+    SCREENSHOT_CHANNELS.GET_SCREEN_PERMISSION,
+    async (event): Promise<ScreenRecordingPermission> => {
+      if (!validateMainRendererSender(event)) {
+        logger.warn('Rejected screenshot:getScreenPermission from untrusted sender', {
+          url: event.senderFrame?.url
+        })
+        return 'unknown'
+      }
+      try {
+        return service.getScreenRecordingPermission()
+      } catch (error) {
+        logger.error(
+          'getScreenRecordingPermission failed',
+          error instanceof Error ? error : undefined
+        )
+        return 'unknown'
       }
     }
   )

--- a/src/main/ipc/system-handlers.test.ts
+++ b/src/main/ipc/system-handlers.test.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2025-2026 Qodeca sp. z o.o.
+/**
+ * Tests for the system IPC handlers (screen-recording settings deep link +
+ * graceful relaunch). Both handlers are sender-gated and the relaunch uses
+ * `app.quit()` (not `app.exit`) so `before-quit` cleanup (project lock
+ * release, watcher disposal) still runs.
+ */
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
+import type { IpcMainInvokeEvent } from 'electron'
+import { SYSTEM_CHANNELS } from '../../shared/ipc/system-channels'
+
+const mockIpcMainHandle = vi.fn()
+const mockOpenExternal = vi.fn((_url: string) => Promise.resolve())
+const mockRelaunch = vi.fn()
+const mockQuit = vi.fn()
+const mockExit = vi.fn((_code?: number) => {})
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: mockIpcMainHandle },
+  shell: { openExternal: (url: string) => mockOpenExternal(url) },
+  app: {
+    relaunch: () => mockRelaunch(),
+    quit: () => mockQuit(),
+    exit: (code?: number) => mockExit(code)
+  }
+}))
+
+const mockIsTrusted = vi.fn(() => true)
+vi.mock('./senderValidation', () => ({ isTrustedSender: (e: unknown) => mockIsTrusted(e) }))
+
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
+vi.mock('../services/LoggingService', () => ({ logger: mockLogger }))
+
+const EVENT = {} as IpcMainInvokeEvent
+
+async function getHandler(channel: string): Promise<(...a: unknown[]) => Promise<unknown> | unknown> {
+  const { registerSystemHandlers } = await import('./system-handlers')
+  registerSystemHandlers()
+  const handler = mockIpcMainHandle.mock.calls.find((c) => c[0] === channel)?.[1]
+  expect(handler).toBeDefined()
+  return handler
+}
+
+describe('system-handlers', () => {
+  const originalPlatform = process.platform
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    mockIsTrusted.mockReturnValue(true)
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
+  })
+
+  it('registers both system channels', async () => {
+    const { registerSystemHandlers } = await import('./system-handlers')
+    registerSystemHandlers()
+    expect(mockIpcMainHandle).toHaveBeenCalledWith(
+      SYSTEM_CHANNELS.OPEN_SCREEN_RECORDING_SETTINGS,
+      expect.any(Function)
+    )
+    expect(mockIpcMainHandle).toHaveBeenCalledWith(SYSTEM_CHANNELS.RELAUNCH_APP, expect.any(Function))
+  })
+
+  it('opens the Screen Recording pane on darwin for a trusted sender', async () => {
+    const handler = await getHandler(SYSTEM_CHANNELS.OPEN_SCREEN_RECORDING_SETTINGS)
+    await handler(EVENT)
+    expect(mockOpenExternal).toHaveBeenCalledWith(
+      'x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture'
+    )
+  })
+
+  it('does not open the pane off darwin', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    const handler = await getHandler(SYSTEM_CHANNELS.OPEN_SCREEN_RECORDING_SETTINGS)
+    await handler(EVENT)
+    expect(mockOpenExternal).not.toHaveBeenCalled()
+  })
+
+  it('rejects the deep link from an untrusted sender', async () => {
+    mockIsTrusted.mockReturnValue(false)
+    const handler = await getHandler(SYSTEM_CHANNELS.OPEN_SCREEN_RECORDING_SETTINGS)
+    await handler(EVENT)
+    expect(mockOpenExternal).not.toHaveBeenCalled()
+  })
+
+  it('relaunches via app.relaunch() + app.quit() (never app.exit) for a trusted sender', async () => {
+    const handler = await getHandler(SYSTEM_CHANNELS.RELAUNCH_APP)
+    await handler(EVENT)
+    expect(mockRelaunch).toHaveBeenCalledTimes(1)
+    expect(mockQuit).toHaveBeenCalledTimes(1)
+    expect(mockExit).not.toHaveBeenCalled()
+  })
+
+  it('rejects relaunch from an untrusted sender', async () => {
+    mockIsTrusted.mockReturnValue(false)
+    const handler = await getHandler(SYSTEM_CHANNELS.RELAUNCH_APP)
+    await handler(EVENT)
+    expect(mockRelaunch).not.toHaveBeenCalled()
+    expect(mockQuit).not.toHaveBeenCalled()
+  })
+
+  afterAll(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+  })
+})

--- a/src/main/ipc/system-handlers.ts
+++ b/src/main/ipc/system-handlers.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2025-2026 Qodeca sp. z o.o.
+import { app, ipcMain, shell } from 'electron'
+import { SYSTEM_CHANNELS } from '../../shared/ipc/system-channels'
+import { isTrustedSender } from './senderValidation'
+import { logger } from '../services/LoggingService'
+
+/**
+ * System IPC Handlers
+ *
+ * OS-integration actions requested by the renderer's screen-recording
+ * permission flow. Both handlers are sender-gated (`isTrustedSender`) because
+ * a renderer-triggerable app restart would otherwise be a boot-loop DoS lever.
+ *
+ * The deep-link URL is a fixed constant with no renderer-supplied input, so
+ * there is no arbitrary-URL / protocol-injection surface.
+ *
+ * Verified working anchor on macOS 13–15; the legacy
+ * `com.apple.preference.security` scheme is preserved on macOS 26 (reconfirm
+ * during QA).
+ */
+const SCREEN_RECORDING_PANE =
+  'x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture'
+
+export function registerSystemHandlers(): void {
+  ipcMain.handle(SYSTEM_CHANNELS.OPEN_SCREEN_RECORDING_SETTINGS, async (event) => {
+    if (!isTrustedSender(event)) {
+      logger.warn('Rejected system:openScreenRecordingSettings from untrusted sender')
+      return
+    }
+    // Screen Recording is a macOS-only TCC concept; no-op elsewhere.
+    if (process.platform !== 'darwin') return
+    await shell.openExternal(SCREEN_RECORDING_PANE)
+  })
+
+  ipcMain.handle(SYSTEM_CHANNELS.RELAUNCH_APP, (event) => {
+    if (!isTrustedSender(event)) {
+      logger.warn('Rejected system:relaunchApp from untrusted sender')
+      return
+    }
+    logger.info('Relaunching app on user request (permission flow)')
+    app.relaunch()
+    // app.quit() (NOT app.exit) so `before-quit` runs: releases the project
+    // lock and disposes watchers/PTYs before the process ends.
+    app.quit()
+  })
+
+  logger.info('✅ System IPC handlers registered')
+}

--- a/src/main/services/ScreenshotService.test.ts
+++ b/src/main/services/ScreenshotService.test.ts
@@ -19,6 +19,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { systemPreferences } from 'electron'
 
 const macCapabilities = {
   supported: true,
@@ -58,6 +59,10 @@ vi.mock('./screenshot/sharedHelpers', () => ({
   listDisplays: vi.fn(() => [
     { id: 1, label: 'Primary', isPrimary: true, bounds: { x: 0, y: 0, width: 2560, height: 1600 } }
   ])
+}))
+
+vi.mock('electron', () => ({
+  systemPreferences: { getMediaAccessStatus: vi.fn(() => 'granted') }
 }))
 
 function stubCapturer(capabilities = desktopCapabilities) {
@@ -223,6 +228,25 @@ describe('ScreenshotService dispatcher + factory', () => {
         areaCaptureMode: 'native'
       })
       expect(stub.getCapabilities).toHaveBeenCalled()
+    })
+  })
+
+  describe('getScreenRecordingPermission (advisory)', () => {
+    it('returns the systemPreferences screen status on darwin', async () => {
+      const { createScreenshotService } = await import('./ScreenshotService')
+      vi.mocked(systemPreferences.getMediaAccessStatus).mockReturnValue('denied')
+      const service = createScreenshotService(stubCapturer(), 'darwin')
+
+      expect(service.getScreenRecordingPermission()).toBe('denied')
+      expect(systemPreferences.getMediaAccessStatus).toHaveBeenCalledWith('screen')
+    })
+
+    it('returns "unknown" off darwin without querying systemPreferences', async () => {
+      const { createScreenshotService } = await import('./ScreenshotService')
+      const service = createScreenshotService(stubCapturer(), 'win32')
+
+      expect(service.getScreenRecordingPermission()).toBe('unknown')
+      expect(systemPreferences.getMediaAccessStatus).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/main/services/ScreenshotService.ts
+++ b/src/main/services/ScreenshotService.ts
@@ -26,12 +26,14 @@
  * @see Issue #164 lens-review F[8], F[10], F[16], F[31] - Phase 3 refactor
  */
 
+import { systemPreferences } from 'electron'
 import { ErrorCode } from '../../shared/errors'
 import { WINDOW_PICKER } from '../../shared/constants'
 import type {
   DisplayInfo,
   EnumerateWindowsRequest,
   EnumerateWindowsResponse,
+  ScreenRecordingPermission,
   ScreenshotCapabilities,
   ScreenshotCaptureRequest,
   ScreenshotCaptureResponse,
@@ -67,12 +69,16 @@ class UnsupportedCapturer implements IScreenshotCapturer {
 export interface IScreenshotService {
   getDisplays(): DisplayInfo[]
   getCapabilities(): ScreenshotCapabilities
+  getScreenRecordingPermission(): ScreenRecordingPermission
   enumerateWindows(options?: EnumerateWindowsRequest): Promise<EnumerateWindowsResponse>
   capture(request: ScreenshotCaptureRequest): Promise<ScreenshotCaptureResponse>
 }
 
 class ScreenshotService implements IScreenshotService {
-  constructor(private readonly capturer: IScreenshotCapturer) {}
+  constructor(
+    private readonly capturer: IScreenshotCapturer,
+    private readonly platform: NodeJS.Platform = process.platform
+  ) {}
 
   getDisplays(): DisplayInfo[] {
     return listDisplays()
@@ -87,6 +93,19 @@ class ScreenshotService implements IScreenshotService {
    */
   getCapabilities(): ScreenshotCapabilities {
     return this.capturer.getCapabilities()
+  }
+
+  /**
+   * Advisory macOS Screen Recording status, read from Electron's
+   * `systemPreferences.getMediaAccessStatus('screen')`. The renderer uses this
+   * ONLY to enrich the failure-path dialog — never to gate a capture. A stale
+   * in-process read (Electron #36722) must never block a granted user, so the
+   * capture attempt always proceeds regardless of this value. Non-macOS
+   * platforms report `'unknown'` (they have no screen-recording TCC gate).
+   */
+  getScreenRecordingPermission(): ScreenRecordingPermission {
+    if (this.platform !== 'darwin') return 'unknown'
+    return systemPreferences.getMediaAccessStatus('screen') as ScreenRecordingPermission
   }
 
   /**
@@ -139,8 +158,11 @@ export function pickCapturer(platform: NodeJS.Platform): IScreenshotCapturer {
  * Replaces the module-eval singleton that previously froze the platform
  * choice at import time (#164 F[8]).
  */
-export function createScreenshotService(capturer?: IScreenshotCapturer): IScreenshotService {
-  return new ScreenshotService(capturer ?? pickCapturer(process.platform))
+export function createScreenshotService(
+  capturer?: IScreenshotCapturer,
+  platform: NodeJS.Platform = process.platform
+): IScreenshotService {
+  return new ScreenshotService(capturer ?? pickCapturer(platform), platform)
 }
 
 export { ScreenshotService }

--- a/src/main/services/screenshot/MacScreenshotCapturer.test.ts
+++ b/src/main/services/screenshot/MacScreenshotCapturer.test.ts
@@ -59,11 +59,15 @@ vi.mock('os', async (importOriginal) => {
 
 const mockGetAllDisplays = vi.fn()
 const mockGetPrimaryDisplay = vi.fn()
+const mockGetMediaAccessStatus = vi.fn(() => 'granted')
 
 vi.mock('electron', () => ({
   screen: {
     getAllDisplays: mockGetAllDisplays,
     getPrimaryDisplay: mockGetPrimaryDisplay
+  },
+  systemPreferences: {
+    getMediaAccessStatus: (...args: unknown[]) => mockGetMediaAccessStatus(...args)
   }
 }))
 
@@ -91,6 +95,7 @@ describe('MacScreenshotCapturer', () => {
       { id: 1, label: 'Built-in', bounds: { x: 0, y: 0, width: 1920, height: 1080 } }
     ])
     mockGetPrimaryDisplay.mockReturnValue({ id: 1 })
+    mockGetMediaAccessStatus.mockReturnValue('granted')
     Object.defineProperty(process, 'platform', { value: 'darwin', writable: true })
   })
 
@@ -202,6 +207,25 @@ describe('MacScreenshotCapturer', () => {
 
       expect(result.success).toBe(false)
       expect(result.errorCode).toBe('SCREENSHOT_CANCELLED')
+    })
+
+    it('classifies a missing file as PERMISSION_DENIED when screen status is denied', async () => {
+      // A denied capture can exit 0 (or 1) and produce no file without the
+      // 'cannot capture' stderr. The authoritative TCC status disambiguates a
+      // silent denial from a real user cancel. Capture is still attempted.
+      mockGetMediaAccessStatus.mockReturnValue('denied')
+      mockExecFile.mockImplementation((_p, _a, _o, cb) => {
+        cb(null, '', '')
+        return new EventEmitter() as ChildProcess
+      })
+      mockAccess.mockRejectedValue(new Error('ENOENT'))
+      const { MacScreenshotCapturer } = await import('./MacScreenshotCapturer')
+
+      const result = await new MacScreenshotCapturer().capture({ mode: 'screen' })
+
+      expect(mockExecFile).toHaveBeenCalledTimes(1) // never pre-skipped
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('SCREENSHOT_PERMISSION_DENIED')
     })
 
     it('returns SCREENSHOT_CANCELLED on exit code 1 + missing file', async () => {

--- a/src/main/services/screenshot/MacScreenshotCapturer.ts
+++ b/src/main/services/screenshot/MacScreenshotCapturer.ts
@@ -21,10 +21,11 @@
  */
 
 import { execFile } from 'child_process'
-import { screen } from 'electron'
+import { screen, systemPreferences } from 'electron'
 import { SCREENSHOT } from '../../../shared/constants'
 import { ErrorCode } from '../../../shared/errors'
 import type {
+  ScreenRecordingPermission,
   ScreenshotCapabilities,
   ScreenshotCaptureRequest,
   ScreenshotCaptureResponse,
@@ -35,6 +36,18 @@ import { fileExists, generateScreenshotPath, sleep } from './sharedHelpers'
 import type { IScreenshotCapturer } from './types'
 
 export class MacScreenshotCapturer implements IScreenshotCapturer {
+  /**
+   * @param getScreenPermission Advisory TCC probe used ONLY to classify an
+   *   ambiguous capture failure (see `runCapture`). Injected for testability;
+   *   defaults to Electron's `systemPreferences.getMediaAccessStatus('screen')`.
+   *   It is never consulted before a capture — the capture is always attempted,
+   *   so a stale read cannot block a granted user.
+   */
+  constructor(
+    private readonly getScreenPermission: () => ScreenRecordingPermission = () =>
+      systemPreferences.getMediaAccessStatus('screen') as ScreenRecordingPermission
+  ) {}
+
   getCapabilities(): ScreenshotCapabilities {
     return { supported: true, hasNativeWindowPicker: true, areaCaptureMode: 'native' }
   }
@@ -135,6 +148,19 @@ export class MacScreenshotCapturer implements IScreenshotCapturer {
 
       const exists = await fileExists(filePath)
       if (!exists) {
+        // No file can mean a real user cancel (Escape) OR a silent denial —
+        // on modern macOS a denied capture can exit 0 with no file and no
+        // `cannot capture` stderr. The authoritative TCC status disambiguates.
+        // The capture was already attempted, so this never blocks a granted
+        // user (status would be 'granted' and we keep the cancel outcome).
+        if (this.getScreenPermission() === 'denied') {
+          logger.warn('Screenshot produced no file and screen status is denied')
+          return {
+            success: false,
+            error: 'Screen recording permission required',
+            errorCode: ErrorCode.SCREENSHOT_PERMISSION_DENIED
+          }
+        }
         logger.debug('Screenshot cancelled - file not created')
         return {
           success: false,

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -15,7 +15,8 @@ import type {
   GetDisplaysResponse,
   EnumerateWindowsRequest,
   EnumerateWindowsResponse,
-  ScreenshotCapabilities
+  ScreenshotCapabilities,
+  ScreenRecordingPermission
 } from '../shared/ipc/screenshot-schema'
 import type {
   CameraSaveRequest,
@@ -285,9 +286,21 @@ declare global {
         capture: (request: ScreenshotCaptureRequest) => Promise<ScreenshotCaptureResponse>
         /** Platform capability matrix (#164 F[31]) */
         getCapabilities: () => Promise<ScreenshotCapabilities>
+        /** Advisory macOS Screen Recording status ('unknown' off macOS) */
+        getScreenPermission: () => Promise<ScreenRecordingPermission>
         // Overlay-only verbs are NOT exposed here (#164 F[6]). The overlay
         // window's preload (`src/preload/screenshotOverlay.ts`) exposes them
         // as `window.overlayApi.areaSelected` / `areaCancelled`.
+      }
+      /**
+       * System / OS-integration actions for the screen-recording permission
+       * flow. Both handlers are sender-gated main-side.
+       */
+      system: {
+        /** Open the macOS Screen Recording privacy pane (no-op off macOS) */
+        openScreenRecordingSettings: () => Promise<void>
+        /** Relaunch the app (graceful shutdown, then restart) */
+        relaunchApp: () => Promise<void>
       }
       /**
        * Camera photo capture operations

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -15,7 +15,8 @@ import type {
   GetDisplaysResponse,
   EnumerateWindowsRequest,
   EnumerateWindowsResponse,
-  ScreenshotCapabilities
+  ScreenshotCapabilities,
+  ScreenRecordingPermission
 } from '../shared/ipc/screenshot-schema'
 import type {
   CameraSaveRequest,
@@ -646,7 +647,16 @@ const api = {
      * `getPlatform()` so platform routing stays single-sourced in main.
      */
     getCapabilities: (): Promise<ScreenshotCapabilities> =>
-      ipcRenderer.invoke('screenshot:getCapabilities')
+      ipcRenderer.invoke('screenshot:getCapabilities'),
+
+    /**
+     * Advisory macOS Screen Recording status (`'granted' | 'denied' |
+     * 'not-determined' | 'restricted' | 'unknown'`). Non-macOS returns
+     * `'unknown'`. Used ONLY to enrich the denial dialog — never to gate a
+     * capture. See `system.openScreenRecordingSettings` / `relaunchApp`.
+     */
+    getScreenPermission: (): Promise<ScreenRecordingPermission> =>
+      ipcRenderer.invoke('screenshot:getScreenPermission')
 
     // Note (#164 lens-review F[6]): the overlay-only verbs
     // (`areaSelected` / `areaCancelled`) are intentionally NOT exposed here.
@@ -654,6 +664,22 @@ const api = {
     // by the per-display area-select overlay BrowserWindows. Exposing them
     // to every renderer would let any compromised window forge a selection
     // or DoS an active capture.
+  },
+
+  /**
+   * System / OS-integration actions for the screen-recording permission flow.
+   * Both are sender-gated main-side.
+   */
+  system: {
+    /** Open the macOS Screen Recording privacy pane (no-op off macOS). */
+    openScreenRecordingSettings: (): Promise<void> =>
+      ipcRenderer.invoke('system:openScreenRecordingSettings'),
+
+    /**
+     * Relaunch the app (macOS applies a fresh Screen Recording grant only to
+     * a newly-launched process). Runs graceful shutdown before restarting.
+     */
+    relaunchApp: (): Promise<void> => ipcRenderer.invoke('system:relaunchApp')
   },
 
   /**

--- a/src/renderer/src/components/Dialog/ScreenPermissionDialog.test.tsx
+++ b/src/renderer/src/components/Dialog/ScreenPermissionDialog.test.tsx
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2025-2026 Qodeca sp. z o.o.
+/**
+ * Tests for ScreenPermissionDialog — the macOS grant-and-relaunch flow shown
+ * when a screenshot is denied. Verifies the settings deep-link and relaunch
+ * bridge calls plus the close affordance.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { ScreenPermissionDialog } from './ScreenPermissionDialog'
+import { TEST_IDS } from '../../constants/testids'
+
+const openSettings = vi.fn(() => Promise.resolve())
+const relaunchApp = vi.fn(() => Promise.resolve())
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  if (!document.getElementById('portal-root')) {
+    const portalRoot = document.createElement('div')
+    portalRoot.id = 'portal-root'
+    document.body.appendChild(portalRoot)
+  }
+  // Extend window.api (never vi.stubGlobal('window', ...) — it destroys React DOM internals).
+  ;(window as unknown as { api: unknown }).api = {
+    system: { openScreenRecordingSettings: openSettings, relaunchApp }
+  }
+})
+
+describe('ScreenPermissionDialog', () => {
+  it('renders nothing when closed', () => {
+    render(<ScreenPermissionDialog isOpen={false} onClose={vi.fn()} status="denied" zIndex={10000} />)
+    expect(screen.queryByTestId(TEST_IDS.SCREEN_PERMISSION_DIALOG)).not.toBeInTheDocument()
+  })
+
+  it('renders the dialog when open', () => {
+    render(<ScreenPermissionDialog isOpen={true} onClose={vi.fn()} status="denied" zIndex={10000} />)
+    expect(screen.getByTestId(TEST_IDS.SCREEN_PERMISSION_DIALOG)).toBeInTheDocument()
+  })
+
+  it('opens Screen Recording settings via the system bridge', () => {
+    render(<ScreenPermissionDialog isOpen={true} onClose={vi.fn()} status="denied" zIndex={10000} />)
+    fireEvent.click(screen.getByTestId(TEST_IDS.SCREEN_PERMISSION_BTN_OPEN_SETTINGS))
+    expect(openSettings).toHaveBeenCalledTimes(1)
+  })
+
+  it('relaunches the app via the system bridge', () => {
+    render(<ScreenPermissionDialog isOpen={true} onClose={vi.fn()} status="denied" zIndex={10000} />)
+    fireEvent.click(screen.getByTestId(TEST_IDS.SCREEN_PERMISSION_BTN_RELAUNCH))
+    expect(relaunchApp).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose when the close button is clicked', () => {
+    const onClose = vi.fn()
+    render(<ScreenPermissionDialog isOpen={true} onClose={onClose} status="denied" zIndex={10000} />)
+    fireEvent.click(screen.getByTestId(TEST_IDS.SCREEN_PERMISSION_BTN_CLOSE))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/Dialog/ScreenPermissionDialog.tsx
+++ b/src/renderer/src/components/Dialog/ScreenPermissionDialog.tsx
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2025-2026 Qodeca sp. z o.o.
+/**
+ * ScreenPermissionDialog
+ *
+ * Shown when a macOS screenshot is denied for lack of Screen Recording
+ * permission. Replaces the previous dead-end error toast with an actionable
+ * flow: open the Screen Recording settings pane, then relaunch Erfana (macOS
+ * applies a fresh grant only to a newly-launched process).
+ *
+ * Advisory only — this dialog never blocks a capture; it appears after the OS
+ * itself has denied one. `status` enriches the copy but does not gate anything.
+ */
+import { useId } from 'react'
+import { ShieldAlert } from 'lucide-react'
+import type { ScreenRecordingPermission } from '../../../../shared/ipc/screenshot-schema'
+import { BaseDialog } from './BaseDialog'
+import { TEST_IDS } from '../../constants/testids'
+
+interface ScreenPermissionDialogProps {
+  /** Whether the dialog is visible */
+  isOpen: boolean
+  /** Called on Close, Escape, or backdrop click */
+  onClose: () => void
+  /** Advisory macOS permission status (used only to tailor the copy) */
+  status: ScreenRecordingPermission
+  /** Z-index for portal layering */
+  zIndex: number
+}
+
+export function ScreenPermissionDialog({
+  isOpen,
+  onClose,
+  status,
+  zIndex
+}: ScreenPermissionDialogProps) {
+  const titleId = `screen-permission-title-${useId()}`
+  const bodyId = `screen-permission-body-${useId()}`
+
+  const handleOpenSettings = (): void => {
+    void window.api.system.openScreenRecordingSettings()
+  }
+
+  const handleRelaunch = (): void => {
+    void window.api.system.relaunchApp()
+  }
+
+  return (
+    <BaseDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      zIndex={zIndex}
+      closeOnBackdrop={true}
+      closeOnEscape={true}
+      ariaLabelledBy={titleId}
+      ariaDescribedBy={bodyId}
+    >
+      <div data-testid={TEST_IDS.SCREEN_PERMISSION_DIALOG}>
+        <div className="dialog-header-with-icon">
+          <div className="dialog-icon">
+            <ShieldAlert size={20} strokeWidth={2} />
+          </div>
+          <h3 id={titleId} className="dialog-title">
+            Screen Recording permission needed
+          </h3>
+        </div>
+
+        <div className="dialog-body">
+          <p id={bodyId} className="dialog-message">
+            {status === 'denied'
+              ? 'Erfana is currently blocked from recording the screen. '
+              : ''}
+            To take screenshots, enable Screen Recording for Erfana in System
+            Settings, then relaunch Erfana for the change to take effect.
+          </p>
+        </div>
+
+        <div className="dialog-actions">
+          <button
+            className="dialog-btn dialog-btn-secondary"
+            onClick={onClose}
+            data-testid={TEST_IDS.SCREEN_PERMISSION_BTN_CLOSE}
+          >
+            Close
+          </button>
+          <button
+            className="dialog-btn dialog-btn-secondary"
+            onClick={handleRelaunch}
+            data-testid={TEST_IDS.SCREEN_PERMISSION_BTN_RELAUNCH}
+          >
+            Relaunch Erfana
+          </button>
+          <button
+            className="dialog-btn dialog-btn-primary"
+            onClick={handleOpenSettings}
+            data-testid={TEST_IDS.SCREEN_PERMISSION_BTN_OPEN_SETTINGS}
+          >
+            Open Screen Recording settings
+          </button>
+        </div>
+      </div>
+    </BaseDialog>
+  )
+}

--- a/src/renderer/src/components/Dialog/index.ts
+++ b/src/renderer/src/components/Dialog/index.ts
@@ -16,6 +16,7 @@ export { ConflictDialog } from './ConflictDialog'
 export { ScreenSelectDialog } from './ScreenSelectDialog'
 export { WindowPickerDialog } from './WindowPickerDialog'
 export { CameraDialog } from './CameraDialog'
+export { ScreenPermissionDialog } from './ScreenPermissionDialog'
 export { showGlobalDialog, subscribeGlobalDialogs } from './dialogService'
 export type { PromptDialogResult } from './PromptDialog'
 

--- a/src/renderer/src/components/Panels/TerminalPanel.tsx
+++ b/src/renderer/src/components/Panels/TerminalPanel.tsx
@@ -31,7 +31,12 @@ import { useProjectManagementContextSafe } from '../../context/ProjectManagement
 import { useTerminalPortalOptional } from '../../context/TerminalPortalContext'
 import { TerminalContextMenu } from '../ContextMenu/TerminalContextMenu'
 import { FilePickerDialog } from '../Dialog/FilePickerDialog'
-import { ScreenSelectDialog, WindowPickerDialog, CameraDialog } from '../Dialog'
+import {
+  ScreenSelectDialog,
+  WindowPickerDialog,
+  CameraDialog,
+  ScreenPermissionDialog
+} from '../Dialog'
 import { useScreenshotCapture } from './TerminalPanel/hooks/useScreenshotCapture'
 import { sanitizeFilePath, getBasename } from '../../utils/fileUtils'
 import { formatPathsForTerminal, escapePathForShell, type ShellKind } from '../../utils/shellPathEscape'
@@ -95,7 +100,10 @@ export function TerminalPanel(_props: ISplitviewPanelProps) {
     setShowWindowPickerDialog,
     refreshDisplays,
     refreshWindowSources,
-    handleScreenshot
+    handleScreenshot,
+    screenPermissionDialogOpen,
+    screenPermissionStatus,
+    closeScreenPermissionDialog
   } = useScreenshotCapture({ terminalIdRef, shellKindRef, xtermRef })
   const [isLoadingWindowSources, setIsLoadingWindowSources] = useState(false)
 
@@ -1202,6 +1210,12 @@ export function TerminalPanel(_props: ISplitviewPanelProps) {
                         handleScreenshot('screen', { displayId })
                       }}
                       onCancel={() => setShowScreenSelectDialog(false)}
+                    />
+                    <ScreenPermissionDialog
+                      isOpen={screenPermissionDialogOpen}
+                      status={screenPermissionStatus}
+                      zIndex={10000}
+                      onClose={closeScreenPermissionDialog}
                     />
                     <button
                       className={`icon-btn${capturingMode === 'window' ? ' icon-btn--loading' : ''}`}

--- a/src/renderer/src/components/Panels/TerminalPanel/hooks/useScreenshotCapture.test.ts
+++ b/src/renderer/src/components/Panels/TerminalPanel/hooks/useScreenshotCapture.test.ts
@@ -53,7 +53,10 @@ const mockEnumerateWindows = vi.fn()
 const mockCapture = vi.fn()
 const mockGetPlatform = vi.fn()
 const mockGetCapabilities = vi.fn()
+const mockGetScreenPermission = vi.fn()
 const mockTerminalWrite = vi.fn()
+const mockOpenScreenRecordingSettings = vi.fn()
+const mockRelaunchApp = vi.fn()
 
 Object.defineProperty(global.window, 'api', {
   writable: true,
@@ -63,7 +66,12 @@ Object.defineProperty(global.window, 'api', {
       getDisplays: mockGetDisplays,
       enumerateWindows: mockEnumerateWindows,
       capture: mockCapture,
-      getCapabilities: mockGetCapabilities
+      getCapabilities: mockGetCapabilities,
+      getScreenPermission: mockGetScreenPermission
+    },
+    system: {
+      openScreenRecordingSettings: mockOpenScreenRecordingSettings,
+      relaunchApp: mockRelaunchApp
     },
     terminal: {
       write: mockTerminalWrite
@@ -112,6 +120,7 @@ describe('useScreenshotCapture', () => {
     mockGetDisplays.mockResolvedValue({ displays: [mockDisplay] })
     mockEnumerateWindows.mockResolvedValue({ sources: [mockWindowSource] })
     mockCapture.mockResolvedValue({ success: true, filePath: '/tmp/screenshot.png' })
+    mockGetScreenPermission.mockResolvedValue('denied')
     mockTerminalWrite.mockResolvedValue(undefined)
     // Default: macOS-style capabilities (supported, native picker). Tests
     // that exercise Windows / unsupported flows override per-test.
@@ -398,7 +407,9 @@ describe('useScreenshotCapture', () => {
       )
     })
 
-    it('shows error toast on SCREENSHOT_PERMISSION_DENIED', async () => {
+    it('opens the permission dialog on SCREENSHOT_PERMISSION_DENIED (macOS)', async () => {
+      mockGetPlatform.mockReturnValue('darwin')
+      mockGetScreenPermission.mockResolvedValue('denied')
       mockCapture.mockResolvedValue({
         success: false,
         errorCode: 'SCREENSHOT_PERMISSION_DENIED'
@@ -412,10 +423,57 @@ describe('useScreenshotCapture', () => {
         await result.current.handleScreenshot('window')
       })
 
+      // Capture is always attempted — never gated by a status pre-check.
+      expect(mockCapture).toHaveBeenCalledTimes(1)
+      // On denial the actionable dialog opens instead of a dead-end toast.
+      expect(result.current.screenPermissionDialogOpen).toBe(true)
+      expect(result.current.screenPermissionStatus).toBe('denied')
+      expect(showErrorToast).not.toHaveBeenCalled()
+    })
+
+    it('falls back to a toast on SCREENSHOT_PERMISSION_DENIED (non-macOS)', async () => {
+      mockGetPlatform.mockReturnValue('win32')
+      mockGetCapabilities.mockResolvedValue({
+        supported: true,
+        hasNativeWindowPicker: false,
+        areaCaptureMode: 'overlay'
+      })
+      mockCapture.mockResolvedValue({
+        success: false,
+        errorCode: 'SCREENSHOT_PERMISSION_DENIED'
+      })
+      const refs = createRefs()
+      const { result } = renderHook(() => useScreenshotCapture(refs))
+
+      await waitFor(() => expect(result.current.isScreenshotSupported).toBe(true))
+
+      await act(async () => {
+        await result.current.handleScreenshot('window', { windowId: 'window:1:0' })
+      })
+
       expect(showErrorToast).toHaveBeenCalledWith(
         'Permission required',
-        'Grant screen recording permission in System Settings > Privacy & Security'
+        expect.stringContaining('screen recording')
       )
+      expect(result.current.screenPermissionDialogOpen).toBe(false)
+    })
+
+    it('closeScreenPermissionDialog closes the dialog', async () => {
+      mockGetPlatform.mockReturnValue('darwin')
+      mockCapture.mockResolvedValue({ success: false, errorCode: 'SCREENSHOT_PERMISSION_DENIED' })
+      const refs = createRefs()
+      const { result } = renderHook(() => useScreenshotCapture(refs))
+      await waitFor(() => expect(result.current.isScreenshotSupported).toBe(true))
+
+      await act(async () => {
+        await result.current.handleScreenshot('window')
+      })
+      expect(result.current.screenPermissionDialogOpen).toBe(true)
+
+      act(() => {
+        result.current.closeScreenPermissionDialog()
+      })
+      expect(result.current.screenPermissionDialogOpen).toBe(false)
     })
 
     it('shows error toast on SCREENSHOT_WINDOW_NOT_FOUND', async () => {

--- a/src/renderer/src/components/Panels/TerminalPanel/hooks/useScreenshotCapture.ts
+++ b/src/renderer/src/components/Panels/TerminalPanel/hooks/useScreenshotCapture.ts
@@ -22,7 +22,9 @@ import {
 } from '../../../../utils/toastHelpers'
 import { escapePathForShell, type ShellKind } from '../../../../utils/shellPathEscape'
 import { getBasename } from '../../../../utils/fileUtils'
+import { isMacOS } from '../../../../utils/platform'
 import { logger } from '../../../../utils/logger'
+import type { ScreenRecordingPermission } from '../../../../../../shared/ipc/screenshot-schema'
 import type { ScreenshotCaptureMode, DisplayInfo, WindowSource } from '../types'
 
 /**
@@ -85,6 +87,15 @@ export interface UseScreenshotCaptureReturn {
     mode: ScreenshotCaptureMode,
     options?: { displayId?: number; windowId?: string }
   ) => Promise<void>
+  /**
+   * Whether the macOS Screen Recording permission dialog is open. Opened from
+   * the capture-failure path (never gates a capture attempt).
+   */
+  screenPermissionDialogOpen: boolean
+  /** Advisory permission status shown in the dialog copy. */
+  screenPermissionStatus: ScreenRecordingPermission
+  /** Dismiss the Screen Recording permission dialog. */
+  closeScreenPermissionDialog: () => void
 }
 
 /**
@@ -124,6 +135,13 @@ export function useScreenshotCapture(
   const [windowSources, setWindowSources] = useState<WindowSource[]>([])
   const [showScreenSelectDialog, setShowScreenSelectDialog] = useState(false)
   const [showWindowPickerDialog, setShowWindowPickerDialog] = useState(false)
+  const [screenPermissionDialogOpen, setScreenPermissionDialogOpen] = useState(false)
+  const [screenPermissionStatus, setScreenPermissionStatus] =
+    useState<ScreenRecordingPermission>('unknown')
+
+  const closeScreenPermissionDialog = useCallback(() => {
+    setScreenPermissionDialogOpen(false)
+  }, [])
 
   // Consult main for platform capabilities on mount (#164 lens-review F[31]).
   // Replaces the previous `getPlatform()` branch — keeping the platform
@@ -216,12 +234,23 @@ export function useScreenshotCapture(
             case 'SCREENSHOT_TIMEOUT':
               showErrorToast('Timeout', 'Screenshot capture timed out after 30 seconds')
               return
-            case 'SCREENSHOT_PERMISSION_DENIED':
-              showErrorToast(
-                'Permission required',
-                'Grant screen recording permission in System Settings > Privacy & Security'
-              )
+            case 'SCREENSHOT_PERMISSION_DENIED': {
+              // The capture was attempted and the OS denied it (never gated by
+              // a status pre-check — a stale read must not block a granted
+              // user). On macOS surface the actionable grant-and-relaunch
+              // dialog; elsewhere fall back to a toast.
+              if (isMacOS()) {
+                const status = await window.api.screenshot.getScreenPermission()
+                setScreenPermissionStatus(status)
+                setScreenPermissionDialogOpen(true)
+              } else {
+                showErrorToast(
+                  'Permission required',
+                  'Grant screen recording permission in system settings'
+                )
+              }
               return
+            }
             case 'SCREENSHOT_WINDOW_NOT_FOUND':
               showErrorToast('Window unavailable', 'The selected window is no longer available')
               return
@@ -295,6 +324,9 @@ export function useScreenshotCapture(
     setShowWindowPickerDialog,
     refreshDisplays,
     refreshWindowSources,
-    handleScreenshot
+    handleScreenshot,
+    screenPermissionDialogOpen,
+    screenPermissionStatus,
+    closeScreenPermissionDialog
   }
 }

--- a/src/renderer/src/constants/testids.test.ts
+++ b/src/renderer/src/constants/testids.test.ts
@@ -90,6 +90,12 @@ describe('TEST_IDS', () => {
       expect(terminalIds).toHaveLength(14)
     })
 
+    it('should have 4 Screen Permission Dialog IDs', async () => {
+      const { TEST_IDS } = await getTestIds()
+      const ids = Object.keys(TEST_IDS).filter((k) => k.startsWith('SCREEN_PERMISSION'))
+      expect(ids).toHaveLength(4)
+    })
+
     it('should have 3 Claude Status Bar IDs', async () => {
       const { TEST_IDS } = await getTestIds()
       const claudeIds = Object.keys(TEST_IDS).filter((k) => k.startsWith('CLAUDE_STATUS_'))

--- a/src/renderer/src/constants/testids.ts
+++ b/src/renderer/src/constants/testids.ts
@@ -133,6 +133,15 @@ export const TEST_IDS = {
   TERMINAL_BTN_CAPTURE_WINDOW: 'terminal-btn-capture-window',
   /** Capture area screenshot button (macOS only) */
   TERMINAL_BTN_CAPTURE_AREA: 'terminal-btn-capture-area',
+  // Screen Recording permission dialog (macOS grant-and-relaunch flow)
+  /** Screen-recording permission dialog container */
+  SCREEN_PERMISSION_DIALOG: 'screen-permission-dialog',
+  /** Open macOS Screen Recording settings pane */
+  SCREEN_PERMISSION_BTN_OPEN_SETTINGS: 'screen-permission-btn-open-settings',
+  /** Relaunch Erfana to apply the granted permission */
+  SCREEN_PERMISSION_BTN_RELAUNCH: 'screen-permission-btn-relaunch',
+  /** Dismiss the permission dialog */
+  SCREEN_PERMISSION_BTN_CLOSE: 'screen-permission-btn-close',
   /** Capture camera photo button (cross-platform) */
   TERMINAL_BTN_CAMERA: 'terminal-btn-camera',
   /** Expand/restore terminal to cover the editor area */

--- a/src/shared/ipc/screenshot-channels.ts
+++ b/src/shared/ipc/screenshot-channels.ts
@@ -54,6 +54,7 @@ export const SCREENSHOT_CHANNELS = {
   CAPTURE: 'screenshot:capture',
   GET_DISPLAYS: 'screenshot:getDisplays',
   GET_CAPABILITIES: 'screenshot:getCapabilities',
+  GET_SCREEN_PERMISSION: 'screenshot:getScreenPermission',
   ENUMERATE_WINDOWS: 'screenshot:enumerateWindows',
   AREA_SELECTED: 'screenshot:areaSelected',
   AREA_CANCELLED: 'screenshot:areaCancelled'

--- a/src/shared/ipc/screenshot-schema.ts
+++ b/src/shared/ipc/screenshot-schema.ts
@@ -272,6 +272,24 @@ export const ScreenshotCapabilitiesSchema = z.object({
 export type ScreenshotCapabilities = z.infer<typeof ScreenshotCapabilitiesSchema>
 
 /**
+ * macOS Screen Recording (kTCCServiceScreenCapture) authorization state,
+ * mirrored from Electron `systemPreferences.getMediaAccessStatus('screen')`.
+ * Non-macOS platforms report `'unknown'` (capture works without a TCC gate).
+ *
+ * Advisory only: the OS/`screencapture` remains the source of truth. This is
+ * used to enrich the failure-path UX, never to gate a capture attempt (a
+ * stale in-process read — Electron #36722 — must never block a granted user).
+ */
+export const ScreenRecordingPermissionSchema = z.enum([
+  'granted',
+  'denied',
+  'not-determined',
+  'restricted',
+  'unknown'
+])
+export type ScreenRecordingPermission = z.infer<typeof ScreenRecordingPermissionSchema>
+
+/**
  * Error codes for screenshot capture failures.
  *
  * Note: CANCELLED is not a true error — it means user pressed Escape.

--- a/src/shared/ipc/system-channels.ts
+++ b/src/shared/ipc/system-channels.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2025-2026 Qodeca sp. z o.o.
+/**
+ * System-level IPC channel constants.
+ *
+ * These back OS-integration actions the renderer can request:
+ * - opening the macOS Screen Recording privacy pane, and
+ * - relaunching the app (needed because macOS only applies a fresh
+ *   Screen Recording grant to a newly-launched process).
+ *
+ * Both handlers are sender-gated main-side (see `system-handlers.ts`).
+ */
+export const SYSTEM_CHANNELS = {
+  OPEN_SCREEN_RECORDING_SETTINGS: 'system:openScreenRecordingSettings',
+  RELAUNCH_APP: 'system:relaunchApp'
+} as const


### PR DESCRIPTION
## Summary

Improves the macOS screenshot **permission-denied** experience: instead of a dead-end error toast, users now get an actionable **"Screen Recording permission needed"** dialog with a one-click deep link to the Screen Recording settings pane and a **Relaunch Erfana** button (macOS applies a fresh grant only to a newly-launched process).

**This is UX hardening for users who have *not* granted permission.** It deliberately does **not** try to suppress macOS's built-in periodic re-authorization (only Apple's VNC-gated `persistent-content-capture` entitlement does that), and it cannot fix a *stale TCC record* — that is a `tccutil reset ScreenCapture com.erfana.app` recovery, not a code change.

## Design: advisory, never blocking

The capture is **always attempted**; `systemPreferences.getMediaAccessStatus('screen')` is read **only after** the OS denies, purely to enrich the dialog. This avoids a regression where a granted user with a stale in-process status read (Electron [#36722](https://github.com/electron/electron/issues/36722)) would be blocked on every capture.

## Changes

- **Shared:** `ScreenRecordingPermission` schema + `screenshot:getScreenPermission` and `system:*` channels.
- **Main:** advisory `getScreenRecordingPermission()` on `ScreenshotService`; sender-gated `screenshot:getScreenPermission` handler; new `system-handlers` (settings deep link + relaunch), both gated with `isTrustedSender`, relaunch via `app.relaunch(); app.quit()` so `before-quit` cleanup (project-lock release, watcher disposal) runs.
- **Capturer:** `MacScreenshotCapturer` classifies a no-file capture as `PERMISSION_DENIED` when TCC status is `denied` (was silently `CANCELLED`) — post-capture only, never pre-skips.
- **Renderer:** `ScreenPermissionDialog` (composes `BaseDialog`); `useScreenshotCapture` opens it on `SCREENSHOT_PERMISSION_DENIED` (macOS), toast fallback elsewhere; wired into `TerminalPanel`.
- **Build:** `NSScreenCaptureUsageDescription` (increasingly enforced on macOS 26).

## Verification

- Lint, typecheck, **8767 unit tests**, and `electron-vite build` all green. TDD throughout (test-first, red→green per task).
- **Not exercised:** the live macOS deny→dialog→relaunch GUI flow — forcing a denied state requires `tccutil reset`, which would re-break a working setup. Logic is fully unit-covered.

## Context

Traced from a "macOS asks for screen-recording permission every time" report; root cause on the affected machine was a **stale TCC record** (fixed by reset, verified). Full investigation + review history in the approved plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
