### PR TITLE
fix(search): cancel pending debounced search on unmount

### DIFF
--- a/src/renderer/src/components/Search/SearchBar.test.tsx
+++ b/src/renderer/src/components/Search/SearchBar.test.tsx
@@ -693,6 +693,27 @@ describe('SearchBar', () => {
       })
     })
 
+    it('does not apply a pending debounced search after unmount', async () => {
+      const user = userEvent.setup()
+      const { unmount } = render(<SearchBar provider={mockProvider} />)
+
+      // Type to schedule a debounced search (100ms), then unmount before it fires
+      await user.type(screen.getByLabelText('Search in document'), 'test')
+      unmount()
+
+      // Inject matches the way a later mount would see them
+      const matches: SearchMatch[] = [
+        { id: '1', line: 1, startColumn: 0, endColumn: 4, text: 'test' }
+      ]
+      useSearchStore.setState({ matches, currentIndex: 0 })
+
+      // Wait past the debounce window: the cancelled callback must not run
+      await new Promise((resolve) => setTimeout(resolve, 200))
+
+      expect(useSearchStore.getState().matches).toEqual(matches)
+      expect(mockProvider.search).not.toHaveBeenCalled()
+    })
+
     it('updates match count when currentIndex changes', async () => {
       const matches: SearchMatch[] = [
         { id: '1', line: 1, startColumn: 0, endColumn: 4, text: 'test' },

--- a/src/renderer/src/components/Search/SearchBar.tsx
+++ b/src/renderer/src/components/Search/SearchBar.tsx
@@ -13,17 +13,27 @@ const SEARCH_DEBOUNCE_MS = 100
 /** Focus delay to ensure component is mounted */
 const FOCUS_DELAY_MS = 10
 
+/** A debounced function with a `cancel` for discarding a pending call. */
+type Debounced<TArgs extends unknown[]> = ((...args: TArgs) => void) & {
+  cancel: () => void
+}
+
 /**
  * Creates a debounced function that delays execution until after
  * the specified wait time has elapsed since the last call.
+ *
+ * The returned function exposes `cancel()` to drop a pending call – callers
+ * must invoke it on unmount, otherwise a late callback applies search results
+ * after the search bar is gone (the store is global, so the stale write would
+ * land on whatever is mounted next).
  */
 function debounce<T extends (...args: Parameters<T>) => void>(
   fn: T,
   delay: number
-): (...args: Parameters<T>) => void {
+): Debounced<Parameters<T>> {
   let timeoutId: ReturnType<typeof setTimeout> | null = null
 
-  return (...args: Parameters<T>) => {
+  const debounced = (...args: Parameters<T>): void => {
     if (timeoutId) {
       clearTimeout(timeoutId)
     }
@@ -31,6 +41,15 @@ function debounce<T extends (...args: Parameters<T>) => void>(
       fn(...args)
     }, delay)
   }
+
+  debounced.cancel = (): void => {
+    if (timeoutId) {
+      clearTimeout(timeoutId)
+      timeoutId = null
+    }
+  }
+
+  return debounced
 }
 
 interface SearchBarProps {
@@ -94,6 +113,10 @@ export function SearchBar({ provider }: SearchBarProps) {
       provider.clearHighlights()
     }
   }, [query, options, provider, debouncedSearch, setMatches])
+
+  // Drop any pending debounced search on unmount (or when the debounced
+  // function is recreated) so a late result cannot write to the global store
+  useEffect(() => () => debouncedSearch.cancel(), [debouncedSearch])
 
   // Navigate when currentIndex changes
   // Pass focusEditor: false to prevent Monaco from stealing focus from search input


### PR DESCRIPTION
## Problem

`Quality Checks` went red on `develop` after the #16 merge: `SearchBar.test.tsx > Match count display > updates match count when currentIndex changes` failed with "Unable to find an element with the text: 2 of 2". The failure is unrelated to #16 (docs/specs only) and does not reproduce locally – it is a genuine latent bug that surfaces as a CI flake.

## Root cause

`SearchBar`'s debounced search (100 ms) had no cancellation. When the component unmounted with a call still pending, the timer fired anyway and called `setMatches(...)` on the **global** Zustand search store. In the test suite, a stray timer scheduled by an earlier typing test landed inside a later test and wiped the matches that test had injected – hence the flake. In the app, the same path lets a stale result be applied after the search bar closes.

## Fix

- `debounce()` now returns a function with a `cancel()` method
- `SearchBar` cancels any pending call in a `useEffect` cleanup (unmount, or when the debounced function is recreated)

## Verification

- New regression test `does not apply a pending debounced search after unmount` – confirmed it **fails** with the cancel removed and passes with it
- `SearchBar.test.tsx`: 54/54 pass
- Full suite: 299 files, 8768 tests pass; lint and typecheck green